### PR TITLE
Control automatic port forwarding with a devcontainer.json file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Allow specifying port forwarding behavior in devcontainer.json
+
 ## [0.0.4] - 2025-02-21
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.changelog) // Gradle Changelog Plugin
     alias(libs.plugins.qodana) // Gradle Qodana Plugin
     alias(libs.plugins.kover) // Gradle Kover Plugin
+    kotlin("plugin.serialization") version "2.1.10"
 }
 
 group = properties("pluginGroup").get()
@@ -24,7 +25,7 @@ repositories {
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
 //    implementation(libs.annotations)
-    implementation("org.json:json:20210307")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
 }
 
 // Set the JVM language level used to build the project.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ repositories {
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
 //    implementation(libs.annotations)
+    implementation("org.json:json:20210307")
 }
 
 // Set the JVM language level used to build the project.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,11 @@ repositories {
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
 //    implementation(libs.annotations)
+    // We need kotlinx-serialization-json >= 1.7.0 to support allowComments, as
+    // devcontainer.json files often have comments and therefore use
+    // nonstandard JSON syntax. This dependency should be marked compileOnly
+    // once the minimum IDE version we support (pluginSinceBuild in
+    // gradle.properties) is at least 251, which includes version 1.7.2.
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
 }
 

--- a/src/main/kotlin/com/coder/jetbrains/matcher/PortMatcher.kt
+++ b/src/main/kotlin/com/coder/jetbrains/matcher/PortMatcher.kt
@@ -1,0 +1,50 @@
+package com.coder.jetbrains.matcher
+
+class PortMatcher(private val rule: String) {
+    private sealed class MatchRule {
+        data class SinglePort(val port: Int) : MatchRule()
+        data class PortRange(val start: Int, val end: Int) : MatchRule()
+        data class RegexPort(val pattern: Regex) : MatchRule()
+    }
+
+    private val parsedRule: MatchRule
+
+    init {
+        parsedRule = parseRule(rule)
+    }
+
+    fun matches(port: Int): Boolean {
+        return when (parsedRule) {
+            is MatchRule.SinglePort -> port == parsedRule.port
+            is MatchRule.PortRange -> port in parsedRule.start..parsedRule.end
+            is MatchRule.RegexPort -> parsedRule.pattern.matches(port.toString())
+        }
+    }
+
+    private fun parseRule(rule: String): MatchRule {
+        // Remove host part if present (e.g., "localhost:3000" -> "3000")
+        val portPart = rule.substringAfter(':').takeIf { ':' in rule } ?: rule
+
+        return when {
+            // Try parsing as single port
+            portPart.all { it.isDigit() } -> {
+                MatchRule.SinglePort(portPart.toInt())
+            }
+            // Try parsing as port range (e.g., "40000-55000")
+            portPart.matches("^\\d+-\\d+$".toRegex()) -> {
+                val (start, end) = portPart.split('-')
+                    .map { it.trim().toInt() }
+                require(start <= end) { "Invalid port range: start must be less than or equal to end" }
+                MatchRule.PortRange(start, end)
+            }
+            // If not a single port or range, treat as regex
+            else -> {
+                try {
+                    MatchRule.RegexPort(portPart.toRegex())
+                } catch (e: Exception) {
+                    throw IllegalArgumentException("Invalid port rule format: $rule")
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/coder/jetbrains/matcher/PortMatcher.kt
+++ b/src/main/kotlin/com/coder/jetbrains/matcher/PortMatcher.kt
@@ -7,11 +7,7 @@ class PortMatcher(private val rule: String) {
         data class RegexPort(val pattern: Regex) : MatchRule()
     }
 
-    private val parsedRule: MatchRule
-
-    init {
-        parsedRule = parseRule(rule)
-    }
+    private val parsedRule: MatchRule = parseRule(rule)
 
     fun matches(port: Int): Boolean {
         return when (parsedRule) {
@@ -33,12 +29,10 @@ class PortMatcher(private val rule: String) {
                 MatchRule.SinglePort(port)
             }
             // Try parsing as port range (e.g., "40000-55000")
-            portPart.matches("^\\d+-\\d+$".toRegex()) -> {
+            portPart.matches("^\\d+\\s*-\\s*\\d+$".toRegex()) -> {
                 val (start, end) = portPart.split('-')
                     .map { it.trim().toInt() }
-                validatePort(start)
-                validatePort(end)
-                require(start <= end) { "Invalid port range: start must be less than or equal to end" }
+                validatePortRange(start, end)
                 MatchRule.PortRange(start, end)
             }
             // If not a single port or range, treat as regex
@@ -56,7 +50,9 @@ class PortMatcher(private val rule: String) {
         require(port in 0..65535) { "Port number must be between 0 and 65535, got: $port" }
     }
 
-    companion object {
-        const val MAX_PORT = 65535
+    private fun validatePortRange(start: Int, end: Int) {
+        validatePort(start)
+        validatePort(end)
+        require(start <= end) { "Invalid port range: start must be less than or equal to end" }
     }
 }

--- a/src/main/kotlin/com/coder/jetbrains/matcher/PortMatcher.kt
+++ b/src/main/kotlin/com/coder/jetbrains/matcher/PortMatcher.kt
@@ -28,12 +28,16 @@ class PortMatcher(private val rule: String) {
         return when {
             // Try parsing as single port
             portPart.all { it.isDigit() } -> {
-                MatchRule.SinglePort(portPart.toInt())
+                val port = portPart.toInt()
+                validatePort(port)
+                MatchRule.SinglePort(port)
             }
             // Try parsing as port range (e.g., "40000-55000")
             portPart.matches("^\\d+-\\d+$".toRegex()) -> {
                 val (start, end) = portPart.split('-')
                     .map { it.trim().toInt() }
+                validatePort(start)
+                validatePort(end)
                 require(start <= end) { "Invalid port range: start must be less than or equal to end" }
                 MatchRule.PortRange(start, end)
             }
@@ -46,5 +50,13 @@ class PortMatcher(private val rule: String) {
                 }
             }
         }
+    }
+
+    private fun validatePort(port: Int) {
+        require(port in 0..65535) { "Port number must be between 0 and 65535, got: $port" }
+    }
+
+    companion object {
+        const val MAX_PORT = 65535
     }
 }

--- a/src/main/kotlin/com/coder/jetbrains/services/CoderPortForwardService.kt
+++ b/src/main/kotlin/com/coder/jetbrains/services/CoderPortForwardService.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 import org.json.JSONObject
+import com.coder.jetbrains.settings.CoderBackendSettings
 
 /**
  * Automatically forward ports that have something listening on them by scanning
@@ -56,8 +57,7 @@ class CoderPortForwardService(
     }
 
     private fun start() {
-        // TODO: make path configurable?
-        val devcontainerFile = File(System.getProperty("user.home"), ".cache/JetBrains/devcontainer.json")
+        val devcontainerFile = CoderBackendSettings.getDevcontainerFile()
         if (devcontainerFile.exists()) {
             try {
                 val json = devcontainerFile.readText()

--- a/src/main/kotlin/com/coder/jetbrains/services/DevContainerConfig.kt
+++ b/src/main/kotlin/com/coder/jetbrains/services/DevContainerConfig.kt
@@ -1,0 +1,24 @@
+package com.coder.jetbrains.services
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DevContainerConfig(
+    @SerialName("portsAttributes")
+    val portsAttributes: Map<String, PortAttributes> = mapOf(),
+    @SerialName("otherPortsAttributes")
+    val otherPortsAttributes: OtherPortsAttributes? = null
+)
+
+@Serializable
+data class PortAttributes(
+    @SerialName("onAutoForward")
+    val onAutoForward: String = ""
+)
+
+@Serializable
+data class OtherPortsAttributes(
+    @SerialName("onAutoForward")
+    val onAutoForward: String = ""
+)

--- a/src/main/kotlin/com/coder/jetbrains/settings/CoderBackendSettings.kt
+++ b/src/main/kotlin/com/coder/jetbrains/settings/CoderBackendSettings.kt
@@ -1,0 +1,10 @@
+package com.coder.jetbrains.settings
+
+import java.io.File
+
+object CoderBackendSettings {
+    fun getDevcontainerFile(): File {
+        // TODO: make path configurable?
+        return File(System.getProperty("user.home"), ".cache/JetBrains/devcontainer.json")
+    }
+}

--- a/src/test/kotlin/com/coder/jetbrains/matcher/PortMatcherTest.kt
+++ b/src/test/kotlin/com/coder/jetbrains/matcher/PortMatcherTest.kt
@@ -3,6 +3,7 @@ package com.coder.jetbrains.matcher
 import org.junit.Test
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertThrows
 
 class PortMatcherTest {
 
@@ -39,5 +40,25 @@ class PortMatcherTest {
         assertTrue(matcher.matches(8005))
         assertTrue(matcher.matches(8009))
         assertFalse(matcher.matches(8010))
+    }
+
+    @Test
+    fun `test invalid port numbers`() {
+        assertThrows(IllegalArgumentException::class.java) { PortMatcher("65536") }
+        assertThrows(IllegalArgumentException::class.java) { PortMatcher("0-65536") }
+        assertThrows(IllegalArgumentException::class.java) { PortMatcher("70000") }
+    }
+
+    @Test
+    fun `test edge case port numbers`() {
+        // These should work
+        PortMatcher("0")
+        PortMatcher("65535")
+        PortMatcher("0-65535")
+
+        // These combinations should work
+        val matcher = PortMatcher("0-65535")
+        assertTrue(matcher.matches(0))
+        assertTrue(matcher.matches(65535))
     }
 }

--- a/src/test/kotlin/com/coder/jetbrains/matcher/PortMatcherTest.kt
+++ b/src/test/kotlin/com/coder/jetbrains/matcher/PortMatcherTest.kt
@@ -1,0 +1,43 @@
+package com.coder.jetbrains.matcher
+
+import org.junit.Test
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+
+class PortMatcherTest {
+
+    @Test
+    fun `test single port`() {
+        val matcher = PortMatcher("3000")
+        assertTrue(matcher.matches(3000))
+        assertFalse(matcher.matches(2999))
+        assertFalse(matcher.matches(3001))
+    }
+
+    @Test
+    fun `test host colon port`() {
+        val matcher = PortMatcher("localhost:3000")
+        assertTrue(matcher.matches(3000))
+        assertFalse(matcher.matches(3001))
+    }
+
+    @Test
+    fun `test port range`() {
+        val matcher = PortMatcher("40000-55000")
+        assertFalse(matcher.matches(39999))
+        assertTrue(matcher.matches(40000))
+        assertTrue(matcher.matches(50000))
+        assertTrue(matcher.matches(55000))
+        assertFalse(matcher.matches(55001))
+    }
+
+    @Test
+    fun `test regex`() {
+        val matcher = PortMatcher("800[1-9]")
+        assertFalse(matcher.matches(8000))
+        assertTrue(matcher.matches(8001))
+        assertTrue(matcher.matches(8005))
+        assertTrue(matcher.matches(8009))
+        assertFalse(matcher.matches(8010))
+    }
+}

--- a/src/test/kotlin/com/coder/jetbrains/matcher/PortMatcherTest.kt
+++ b/src/test/kotlin/com/coder/jetbrains/matcher/PortMatcherTest.kt
@@ -33,6 +33,13 @@ class PortMatcherTest {
     }
 
     @Test
+    fun `test port range with whitespace`() {
+        val matcher = PortMatcher("20021  - 20024")
+        assertFalse(matcher.matches(20000))
+        assertTrue(matcher.matches(20022))
+    }
+
+    @Test
     fun `test regex`() {
         val matcher = PortMatcher("800[1-9]")
         assertFalse(matcher.matches(8000))


### PR DESCRIPTION
`devcontainer.json` has a system for specifying default behavior for forwarding ports, and also behavior for specific ports and ranges of ports. Its schema is essentially identical to the settings VS Code uses to control port forwarding, so supporting this format for port settings keeps things consistent between VS Code and JetBrains.

See https://containers.dev/implementors/json_reference/ for the spec. As an example, this will turn off automatic port forwarding except for ports 7123 and 8100-8150:

    {
      "otherPortsAttributes": {
        "onAutoForward": "ignore"
      },
      "portsAttributes": {
        "7123": {
          "onAutoForward": "notify"
        },
        "8100-8150": {
          "onAutoForward": "notify"
        }
      }
    }

Fixes: #38