### PR TITLE
impl: migrate platform plugin to latest 2.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-          ./gradlew listProductsReleases # prepare list of IDEs for Plugin Verifier
+          ./gradlew printProductsReleases # prepare list of IDEs for Plugin Verifier
 
       # Build plugin
       - name: Build plugin
@@ -214,7 +214,7 @@ jobs:
 
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       - name: Run Plugin Verification tasks
-        run: ./gradlew runPluginVerifier -Dplugin.verifier.home.dir=${{needs.build.outputs.pluginVerifierHomeDir }} --info
+        run: ./gradlew verifyPlugin -Dplugin.verifier.home.dir=${{needs.build.outputs.pluginVerifierHomeDir }} --info
         # Getting "no ComponentUI class for:
         # com.intellij.util.ui.tree.PerFileConfigurableBase$PerFileConfigurableComboBoxAction$1"
         # but it does not seem related to anything the plugin is doing...

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,20 @@
-.gradle
+## Intellij IDEA
+*.iml
+*.eml
+*.ipr
+*.iws
 .idea
-.qodana
+*java.orig
+**/out/*
+
+## Eclipse
+*.classpath
+*.project
+
+## Gradle
+.gradle
 build
+jvm/
+
+## Qodana
+.qodana

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 - Allow specifying port forwarding behavior in devcontainer.json
+- support for IntelliJ 2025.2
 
 ## [0.0.4] - 2025-02-21
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 
 fun properties(key: String) = providers.gradleProperty(key)
 fun environment(key: String) = providers.environmentVariable(key)
@@ -17,68 +18,58 @@ plugins {
 group = properties("pluginGroup").get()
 version = properties("pluginVersion").get()
 
+// Set the JVM language level used to build the project.
+kotlin {
+    jvmToolchain(17)
+}
+
 // Configure project's dependencies
 repositories {
     mavenCentral()
+    // IntelliJ Platform Gradle Plugin Repositories Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-repositories-extension.html
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
-//    implementation(libs.annotations)
+    // implementation(libs.annotations)
     // We need kotlinx-serialization-json >= 1.7.0 to support allowComments, as
     // devcontainer.json files often have comments and therefore use
     // nonstandard JSON syntax. This dependency should be marked compileOnly
     // once the minimum IDE version we support (pluginSinceBuild in
     // gradle.properties) is at least 251, which includes version 1.7.2.
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
-}
 
-// Set the JVM language level used to build the project.
-kotlin {
-    jvmToolchain(17)
+    testImplementation("junit:junit:4.13.2")
+
+    // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
+    intellijPlatform {
+        intellijIdeaCommunity(providers.gradleProperty("platformVersion"))
+
+        // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file for plugin from JetBrains Marketplace.
+        bundledPlugins(providers.gradleProperty("platformBundledPlugins").map { it.split(',') })
+
+        pluginVerifier()
+    }
 }
 
 // Configure Gradle IntelliJ Plugin - read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
-intellij {
-    pluginName = properties("pluginName")
-    version = properties("platformVersion")
-    type = properties("platformType")
+intellijPlatform {
+    buildSearchableOptions = true
+    instrumentCode = true
 
-    // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    plugins = properties("platformPlugins").map { it.split(',').map(String::trim).filter(String::isNotEmpty) }
-}
-
-// Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
-changelog {
-    groups.empty()
-    repositoryUrl = properties("pluginRepositoryUrl")
-}
-
-// Configure Gradle Kover Plugin - read more: https://github.com/Kotlin/kotlinx-kover#configuration
-koverReport {
-    defaults {
-        xml {
-            onCheck = true
-        }
-    }
-}
-
-tasks {
-    wrapper {
-        gradleVersion = properties("gradleVersion").get()
-    }
-
-    patchPluginXml {
-        version = properties("pluginVersion")
-        sinceBuild = properties("pluginSinceBuild")
-        untilBuild = properties("pluginUntilBuild")
+    pluginConfiguration {
+        name = providers.gradleProperty("pluginName")
+        version = providers.gradleProperty("pluginVersion")
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
-        pluginDescription = providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {
+        description = providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {
             val start = "<!-- Plugin description -->"
             val end = "<!-- Plugin description end -->"
 
-            with (it.lines()) {
+            with(it.lines()) {
                 if (!containsAll(listOf(start, end))) {
                     throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
                 }
@@ -88,7 +79,7 @@ tasks {
 
         val changelog = project.changelog // local variable for configuration cache compatibility
         // Get the latest available change notes from the changelog file
-        changeNotes = properties("pluginVersion").map { pluginVersion ->
+        changeNotes = providers.gradleProperty("pluginVersion").map { pluginVersion ->
             with(changelog) {
                 renderItem(
                     (getOrNull(pluginVersion) ?: getUnreleased())
@@ -98,29 +89,93 @@ tasks {
                 )
             }
         }
+
+        ideaVersion {
+            sinceBuild = providers.gradleProperty("pluginSinceBuild")
+            untilBuild = providers.gradleProperty("pluginUntilBuild")
+        }
     }
 
-    // Configure UI tests plugin
-    // Read more: https://github.com/JetBrains/intellij-ui-test-robot
-    runIdeForUiTests {
-        systemProperty("robot-server.port", "8082")
-        systemProperty("ide.mac.message.dialogs.as.sheets", "false")
-        systemProperty("jb.privacy.policy.text", "<!--999.999-->")
-        systemProperty("jb.consents.confirmation.enabled", "false")
+    pluginVerification {
+        ides {
+            providers.gradleProperty("verifyVersions").get().split(',').map(String::trim).forEach { version ->
+                ide(IntelliJPlatformType.IntellijIdeaCommunity, version)
+            }
+        }
     }
 
-    signPlugin {
+    signing {
         certificateChain = environment("CERTIFICATE_CHAIN")
         privateKey = environment("PRIVATE_KEY")
         password = environment("PRIVATE_KEY_PASSWORD")
     }
 
-    publishPlugin {
-        dependsOn("patchChangelog")
-        token = environment("PUBLISH_TOKEN")
+    publishing {
+        token = providers.environmentVariable("PUBLISH_TOKEN")
         // The pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-        channels = properties("pluginVersion").map { listOf(it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" }) }
+        channels = providers.gradleProperty("pluginVersion")
+            .map { listOf(it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" }) }
+    }
+}
+
+
+// Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
+changelog {
+    version.set(properties("pluginVersion"))
+    groups.set(emptyList())
+}
+
+// Configure Gradle Kover Plugin - read more: https://github.com/Kotlin/kotlinx-kover#configuration
+kover {
+    reports {
+        total {
+            xml {
+                onCheck = true
+            }
+        }
+    }
+}
+
+// Configure Gradle Qodana Plugin - read more: https://github.com/JetBrains/gradle-qodana-plugin
+qodana {
+    cachePath.set(projectDir.resolve(".qodana").canonicalPath)
+    resultsPath.set(projectDir.resolve("build/reports/inspections").canonicalPath)
+}
+
+tasks {
+    wrapper {
+        gradleVersion = properties("gradleVersion").get()
+    }
+
+    buildPlugin {
+        archiveBaseName = providers.gradleProperty("pluginName").get()
+//        exclude { "coroutines" in it.name }
+    }
+
+    publishPlugin {
+        dependsOn(patchChangelog)
+    }
+}
+
+intellijPlatformTesting {
+    runIde {
+        register("runIdeForUiTests") {
+            task {
+                jvmArgumentProviders += CommandLineArgumentProvider {
+                    listOf(
+                        "-Drobot-server.port=8082",
+                        "-Dide.mac.message.dialogs.as.sheets=false",
+                        "-Djb.privacy.policy.text=<!--999.999-->",
+                        "-Djb.consents.confirmation.enabled=false",
+                    )
+                }
+            }
+
+            plugins {
+                robotServerPlugin()
+            }
+        }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,7 +150,7 @@ tasks {
     }
 
     buildPlugin {
-        archiveBaseName = providers.gradleProperty("pluginName").get()
+        archiveBaseName = providers.gradleProperty("pluginArtifactName").get()
 //        exclude { "coroutines" in it.name }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.coder.jetbrains
 pluginName = coder-gateway-backend
 pluginRepositoryUrl = https://github.com/coder/jetbrains-backend-coder
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.4
+pluginVersion = 0.1.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,10 +13,11 @@ pluginUntilBuild = 251.*
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
 platformVersion = 2022.3.3
-
+# available releases listed at: https://data.services.jetbrains.com/products?code=IC
+verifyVersions=2025.1
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins=com.jetbrains.codeWithMe, org.jetbrains.plugins.terminal
+platformBundledPlugins=com.jetbrains.codeWithMe, org.jetbrains.plugins.terminal
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,13 +8,13 @@ pluginVersion = 0.0.4
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223
-pluginUntilBuild = 251.*
+pluginUntilBuild = 252.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
 platformVersion = 2022.3.3
 # available releases listed at: https://data.services.jetbrains.com/products?code=IC
-verifyVersions=2025.1
+verifyVersions=2025.1,2025.2
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformBundledPlugins=com.jetbrains.codeWithMe, org.jetbrains.plugins.terminal

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,8 @@
 # IntelliJ Platform Artifacts Repositories -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
 pluginGroup = com.coder.jetbrains
-pluginName = coder-gateway-backend
+pluginName = Coder Gateway Backend
+pluginArtifactName = coder-gateway-backend
 pluginRepositoryUrl = https://github.com/coder/jetbrains-backend-coder
 # SemVer format -> https://semver.org
 pluginVersion = 0.1.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,16 +5,16 @@ annotations = "24.1.0"
 # plugins
 kotlin = "2.0.0"
 changelog = "2.2.0"
-gradleIntelliJPlugin = "1.17.2"
-qodana = "2024.1.5"
-kover = "0.7.6"
+gradleIntelliJPlugin = "2.6.0"
+qodana = "2025.1.1"
+kover = "0.9.1"
 
 [libraries]
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
-gradleIntelliJPlugin = { id = "org.jetbrains.intellij", version.ref = "gradleIntelliJPlugin" }
+gradleIntelliJPlugin = { id = "org.jetbrains.intellij.platform", version.ref = "gradleIntelliJPlugin" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 qodana = { id = "org.jetbrains.qodana", version.ref = "qodana" }


### PR DESCRIPTION
IntelliJ Platform Gradle Plugin 2.x is the build system that supersedes the Gradle IntelliJ Plugin 1.x, and this is the version that also comes with the ability to provide unlimited until buil
d support.

This is a major overhaul of the DSL, I've tested these changes locally with IntelliJ Community 2022 (the minimum supported
version), and I've also compared the plugin.xml and the zip content with a previous version to make sure
it is generated correctly.
